### PR TITLE
Make GitHub Actions builds use only one OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,26 +15,29 @@ jobs:
           21,    # Current Java LTS
         ]
         # and run on both Linux and Windows
-        os: [ubuntu-22.04, windows-2022]
+        os: [windows-latest]
+        # to run on Linux: os: [ubuntu-22.04] (if want artifacts from Linux, other changes needed)
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v5
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - name: make gradle wrapper executable
-        if: ${{ runner.os != 'Windows' }}
-        run: chmod +x ./gradlew
+          # by default Github uses Microsoft one to restore change to 'microsoft'
+#      - name: make gradle wrapper executable
+#        if: ${{ runner.os != 'Windows' }}
+#        run: chmod +x ./gradlew
+# not needed on Windows
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '21' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v4
+        if: ${{ runner.os == 'Windows' && matrix.java == '21' }} # Only upload artifacts built from latest java on one OS
+        uses: actions/upload-artifact@v6
         with:
           name: Artifacts
           path: |


### PR DESCRIPTION
This PR makes GitHub Actions builds use only one OS. The one I have selected is Windows, please let me know if you would like to change it, if you are even interested in merging this at all. This also updates the version of actions used.